### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/vendor
+/composer.lock
+/.idea
+/.phpunit.cache
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,16 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
-    "php": "^8.0",
-    "dreamfactory/df-core": "~1.0"
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core": "~1.0.4"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Services/BaseService.php
+++ b/src/Services/BaseService.php
@@ -19,6 +19,25 @@ abstract class BaseService extends BaseRestService
     protected $ttl = null;
 
     /**
+     * Build a cache key from a caller-supplied resource path that
+     * cannot collide with a different path differing only in the
+     * positions of `/` vs `.`.
+     *
+     * The previous implementation `str_replace('/', '.', $path)` made
+     * `/user/1` and `/user.1` collide — a tenant could read or poison
+     * another tenant's cache by crafting a colliding path. The fix
+     * uses a delimiter that cannot appear in a URL path so distinct
+     * inputs always produce distinct keys.
+     */
+    public static function buildCacheKey(string $resourcePath): string
+    {
+        // ASCII unit-separator (\x1F) is forbidden in URL paths, which
+        // means it can never appear in the input — the two forms can
+        // never round-trip to the same key.
+        return str_replace('/', "\x1F", $resourcePath);
+    }
+
+    /**
      * BaseService constructor.
      *
      * @param array $settings
@@ -51,7 +70,7 @@ abstract class BaseService extends BaseRestService
     /** {@inheritdoc} */
     protected function handleGET()
     {
-        $key = str_replace('/', '.', $this->resourcePath);
+        $key = self::buildCacheKey($this->resourcePath);
         if (empty($key)) {
             throw new BadRequestException('No key/resource provide. Please provide a cache key to retrieve.');
         }
@@ -74,7 +93,7 @@ abstract class BaseService extends BaseRestService
     /** {@inheritdoc} */
     protected function handlePUT()
     {
-        $key = str_replace('/', '.', $this->resourcePath);
+        $key = self::buildCacheKey($this->resourcePath);
         $payload = $this->getPayloadData();
         $this->ttl = $this->request->getParameter('ttl', $this->ttl);
         $forever = $this->request->getParameterAsBool('forever');
@@ -111,7 +130,7 @@ abstract class BaseService extends BaseRestService
     /** {@inheritdoc} */
     protected function handlePOST()
     {
-        $key = str_replace('/', '.', $this->resourcePath);
+        $key = self::buildCacheKey($this->resourcePath);
         $payload = $this->getPayloadData();
 
         if (!empty($key) && true === $this->store->has($key)) {
@@ -142,7 +161,7 @@ abstract class BaseService extends BaseRestService
     /** {@inheritdoc} */
     protected function handleDELETE()
     {
-        $key = str_replace('/', '.', $this->resourcePath);
+        $key = self::buildCacheKey($this->resourcePath);
         if (empty($key)) {
             throw new BadRequestException('No key/resource provide. Please provide a cache key to delete.');
         }

--- a/tests/Security/CacheKeyCollisionTest.php
+++ b/tests/Security/CacheKeyCollisionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace DreamFactory\Core\Cache\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: distinct resource paths must produce distinct cache keys.
+ *
+ * Old behaviour: str_replace('/', '.', $path) made /user/1 and /user.1
+ * collide; a tenant crafting `/user.1` could read or poison the cache
+ * entry meant for `/user/1`.
+ */
+class CacheKeyCollisionTest extends TestCase
+{
+    /**
+     * The class is abstract so we exercise the static helper directly
+     * via reflection of any concrete subclass — but the helper is
+     * static and public, so we can just bridge to it.
+     */
+    private function buildKey(string $path): string
+    {
+        return \DreamFactory\Core\Cache\Services\BaseService::buildCacheKey($path);
+    }
+
+    public function testDistinctInputsProduceDistinctKeys(): void
+    {
+        $a = $this->buildKey('/user/1');
+        $b = $this->buildKey('/user.1');
+        $this->assertNotSame($a, $b, 'cache keys for /user/1 and /user.1 must differ');
+    }
+
+    public function testDeeperPathsAlsoUnique(): void
+    {
+        $a = $this->buildKey('/tenants/42/users/7');
+        $b = $this->buildKey('/tenants.42/users.7');
+        $this->assertNotSame($a, $b);
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
